### PR TITLE
fixing light/dark modes

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,7 +6,7 @@ import Layout from "../components/Layout";
 import { ThemeProvider } from "next-themes";
 function MyApp({ Component, pageProps }) {
   return (
-    <ThemeProvider enableSystem={true} attribute="class">
+    <ThemeProvider enableSystem={false} attribute="class">
       <ChakraProvider>
         <Layout>
           <NextNProgress


### PR DESCRIPTION
This was the actual problem.
There was no default theme whenever the user open this website there is no theme set. 
The theme only sets when the user clicks on the Theme Toggle button only then the local storage set the theme to either "light" or "dark" .
Even the 
```
theme: system 
```
also works but in this scenario there was no code handling it. Therefore it was not working properly. As a result I just made enableSystem to false. which make the 

```
theme: light
```
by default. Now when the user visits the website for the first time the theme should be light by default.

![image](https://user-images.githubusercontent.com/73132031/154698001-308fa8bf-0269-4669-bc12-4153b7014556.png)

demo: https://gssoc-website-new.vercel.app/

which works properly now in my laptop as well.

suggestion:  You can save use all the images that is fetched for different img tags by downloading it in the Public/images folder and using Image tag from next/image
