### PR TITLE
Add alt attribute to footer logo - Resolves #102

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -14,6 +14,7 @@ const Footer = () => {
                 <img
                   className="cursor-pointer"
                   src="./GS_Foundation_logo_Black.svg"
+                  alt="logo"
                 />
               </Link>
             </div>


### PR DESCRIPTION
No alt attribute provided (#102) 

Added the alt attribute to the footer logo in **gssoc-website-new\components\Footer.js**