### PR TITLE
Add details about the badge annoouncment Fixed

### DIFF
--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -546,6 +546,9 @@ function Leaderboard() {
                 {isLoading === false && lastupdated === null && (
                   <>The server is updating. Please comeback after 5-10 mins</>
                 )}
+                <a className="ml-2 underline hover:no-underline" href="https://github.com/GSSoC24/Contributor/discussions/288" target="_blank" rel="noreferrer" >
+                  More details about badges
+                </a>
               </p>
             </div>
 


### PR DESCRIPTION
## Description 
 added details about the badge at specified location.

## Issue

[Issue Link](https://github.com/girlscript/gssoc-website-new/issues/251) resolve #251 

