### PR TITLE
Refactor team member profile page for static website

### DIFF
--- a/pages/team.js
+++ b/pages/team.js
@@ -127,7 +127,7 @@ const Team = () => {
                   <div className="p-3 shadow bg-primary_orange-0 rounded-xl w-full md:h-fit">
                     <div className="h-max rounded-lg shadow-lg md:h-96 relative bottom-7 hover:-translate-y-4 duration-300 hover:cursor-pointer" 
                          title={`Visit ${curElem["Name"]}'s Profile`}>
-                      <Link href={`/team/${curElem["Name"].replace(/\s+/g, '')}`}>
+                      <Link href={`/teamprofile?name=${curElem["Name"].replace(/\s+/g, '')}`}>
                       <img
                         src={curElem.Image}
                         alt="Team Member Photo"

--- a/pages/teamprofile.js
+++ b/pages/teamprofile.js
@@ -1,15 +1,15 @@
 import { useRouter } from "next/router";
 import Head from "next/head";
-import memberData from "../../public/team_member_data/member_data.json";
+import memberData from "../public/team_member_data/member_data.json";
 import { useEffect } from "react";
 
 
 const TeamMember = () => {
     const router = useRouter();
-    const { team_member } = router.query;
-    const member = memberData.find((m) => m[team_member]);
+    const { name } = router.query;
+    const member = memberData.find((m) => m[name]);
 
-    const details = member ? member[team_member] : {};
+    const details = member ? member[name] : {};
     const githubUsername = details.GitHub
         ? details.GitHub.split("/").pop()
         : "";
@@ -51,7 +51,7 @@ const TeamMember = () => {
                 '{"backgroundColor":"#000","color":"#fff","border":"1px solid #000"}'
             );
             script.setAttribute("embed-version", "v1");
-            script.setAttribute("button-text", "Let's Connect");
+            script.setAttribute("button-text", "1:1 Mentorship");
             script.setAttribute("position-right", positionRight);
             script.setAttribute("position-bottom", positionBottom);
             script.setAttribute("custom-padding", "0px");
@@ -61,11 +61,11 @@ const TeamMember = () => {
 
             document.body.appendChild(script);
             return () => {
-                document.body.removeChild(script);
+                if(script)
+                    document.body.removeChild(script);
             };
         }
-    }, [details.TopmateService]);
-    // console.log(githubUsername);
+    }, [details.TopmateService, router.query]);
 
     if (!member) {
         return (


### PR DESCRIPTION
Fixes: https://github.com/GSSoC24/being-an-GSSoc24/issues/137

Reference: https://github.com/girlscript/gssoc-website-new/pull/379

- fixed Refresh error on teams page because of static deployment
- changed `Let's Connect` to `1:1 Mentorship`

Old url = `https://gssoc.girlscript.tech/team/SanjayViswanathan`
New url = `http://localhost:3000/teamprofile?name=SanjayViswanathan`