### PR TITLE
Added Nodemailer and Mails for all role| Added and fixed all Roles other than CA | Added new fields for Resume Upload

### DIFF
--- a/pages/api/registration.js
+++ b/pages/api/registration.js
@@ -1,45 +1,681 @@
-import dbConnect from '../../utils/dbConnect';
-import CA from '../../utils/models/caSchema';
-import Contributors from '../../utils/models/contributorsSchema';
-import Mentor from '../../utils/models/mentorSchema';
-import ProjectAdmin from '../../utils/models/projectAdminSchema';
+import dbConnect from "../../utils/dbConnect";
+import CA from "../../utils/models/caSchema";
+import Contributors from "../../utils/models/contributorsSchema";
+import Mentor from "../../utils/models/mentorSchema";
+import ProjectAdmin from "../../utils/models/projectAdminSchema";
+import nodemailer from "nodemailer";
 
-export default async function handler(req, res) {
+const allowCors = (fn) => async (req, res) => {
+  res.setHeader("Access-Control-Allow-Credentials", true);
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader(
+    "Access-Control-Allow-Methods",
+    "GET,OPTIONS,PATCH,DELETE,POST,PUT"
+  );
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+  );
+
+  if (req.method === "OPTIONS") {
+    res.status(200).end();
+    return;
+  }
+
+  return await fn(req, res);
+};
+
+const handler = async (req, res) => {
   const { method } = req;
 
   console.log(`Received ${method} request`);
 
   await dbConnect();
 
-  if (method === 'POST') {
+  if (method === "POST") {
     try {
       const { role, ...formData } = req.body;
-
+      const email = formData.email;
+      const name = formData.name;
       let savedData;
+      let subject;
+      let body;
+
       switch (role) {
-        case 'CA':
+        case "CA":
           savedData = await CA.create(formData);
+          subject =
+            "Thank You for Applying as a Campus Ambassador for GSSoC '24 Extended! 🌟";
+          body = `
+          <body style="padding: 0; margin: 0; background-color: #f1f1f1; width: 100%; height: 100%;">
+  <div style="width: 90%; max-width: 600px; height: auto; background-color: #ffffff; margin: auto; position: relative; overflow: hidden;">
+    <table cellspacing="0" cellpadding="0" width="100%" align="center">
+      <tbody>
+        <tr>
+          <td valign="middle" width="33.33%" align="center" style="padding-top: 20px; padding-bottom: 20px;">
+            <a target="_blank" style="background-color:white;">
+              <img src="https://github.com/user-attachments/assets/62aa7d8e-5eb1-44b2-aaba-5d0c436a2ce7" alt="" width="100%">
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    
+    <div>
+      <img style="width: 100%; height: auto; object-fit: cover;" src="https://github.com/user-attachments/assets/e8a0dfd6-e243-4594-a209-cde2f48d1505" alt="">
+    </div>
+
+    <div style="height: auto; text-align: center; display: flex; flex-direction: column; justify-content: center; padding: 10px;">
+      <h1 style="font-size: 1.8em; color: #515151;">
+        Thank you for applying to be a Campus Ambassador for GSSoC '24 Extended!
+      </h1>
+    </div>
+
+<div style="padding: 20px;">
+  <p style="font-size: 1.1em; color: #848484; font-weight: 400;">
+    Dear ${name},
+    <br/><br/>
+    We are thrilled to have your support in spreading awareness about open-source and empowering more students to join this incredible journey. 🚀
+    <br/><br/>
+    We are reviewing all applications, and you will receive a confirmation email regarding your selection soon. Please keep an eye on your inbox for further updates!
+    <br/><br/>
+    In the meantime, feel free to spread the word among your friends, college community, and network so they don’t miss out on the exciting opportunities that GSSoC '24 Extended has to offer!
+    <br/><br/>
+    👉 Subscribe to our newsletter to stay informed about all the latest updates.<a href="https://gssoc.substack.com/subscribe">Subscribe</a><br/>
+    👉 Connect with our Program Managers for additional guidance and support:
+    <br/><br/>
+    <ul style="padding-left: 20px;">
+      <li><a href="https://www.linkedin.com/in/sanjay-k-v/" style="color: #515151; text-decoration:none; font-weight: bold;">Sanjay KV</a></li>
+      <li><a href="https://www.linkedin.com/in/hemu21/" style="color: #515151; text-decoration:none; font-weight: bold;">Hemanth Kumar</a></li>
+      <li><a href="https://www.linkedin.com/in/mastan-sayyad-126904223/" style="color: #515151; text-decoration:none; font-weight: bold;">Mastan Sayyad</a></li>
+      <li><a href="https://www.linkedin.com/in/radhikamalpani1702/" style="color: #515151; text-decoration:none; font-weight: bold;">Radhika Malpani</a></li>
+      <li><a href="https://www.linkedin.com/in/suhani-singh-paliwal/" style="color: #515151; text-decoration:none; font-weight: bold;">Suhani Singh Paliwal</a></li>
+    </ul>
+  </p>
+</div>
+
+
+    <div style="background-color: #df551a; color: #ffffff; text-align: center; padding: 20px;">
+      <h1 style="font-size: 1.5em; font-weight: bolder; color: #ffffff;">
+        Our Vision for GSSOC'24 Extended
+      </h1>
+      <p style="font-size: 1.2em;">Empowering Developers, Expanding Horizons</p>
+      <p style="font-size: 1em; font-weight: 200; color: #ffffff;">
+        The GSSoC'24 Extended Program offers an additional 30 days of open-source collaboration following the success of GSSoC'24. This extension allows developers to continue learning, contributing, and growing within the open-source community, fostering innovation and engagement.
+      </p>
+    </div>
+    <div style="padding-right: 20px; padding-left:20px;padding-top:20px;padding-bottom:5px;">
+      <p style="font-size: 1.1em; color: #848484; font-weight: 400;">
+      We look forward to having you as a Campus Ambassador, helping us make GSSoC '24 Extended a memorable and impactful event. Your role will be key to inspiring future contributors!<br/>
+      Stay tuned, and thank you for being a part of this amazing initiative!
+      </p>
+      </div>
+    <div style="height: auto; color: #848484; font-size: 1em; text-align: center; padding: 10px;">
+      <h3>
+            <br/>Best regards,<br/>
+            The GSSoC '24 Extended Team
+      </h3>
+    </div>
+
+    <div style="height: 0.5px; background-color: #515151; margin: 20px 0;"></div>
+
+    <table cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td width="600" align="left">
+            <table cellpadding="0" cellspacing="0" width="100%">
+              <tbody>
+                <tr>
+                  <td align="center" style="font-size: 0;">
+                    <table cellpadding="0" cellspacing="0">
+                      <tbody>
+                        <tr>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://x.com/girlscriptsoc?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor">
+                              <img title="X" src="https://enpntus.stripocdn.email/content/assets/img/social-icons/logo-colored/x-logo-colored.png" alt="X" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://www.instagram.com/girlscriptsummerofcode/?hl=en">
+                              <img title="Instagram" src="https://enpntus.stripocdn.email/content/assets/img/social-icons/logo-colored/instagram-logo-colored.png" alt="Instagram" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://github.com/girlscript">
+                              <img title="GitHub" src="https://enpntus.stripocdn.email/content/assets/img/other-icons/logo-colored/github-logo-colored.png" alt="GitHub" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="mailto:gssoc@girlscript.tech">
+                              <img title="Gmail" src="https://enpntus.stripocdn.email/content/assets/img/other-icons/logo-colored/gmail-logo-colored.png" alt="Gmail" width="32">
+                            </a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center">
+                    <p>GSSoC Extd. © 2024, All Rights Reserved.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <table cellpadding="0" cellspacing="0" width="100%">
+                      <tbody>
+                        <tr>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/" style="color: #999999;">Visit Us</a>
+                          </td>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px; border-left: 1px solid #cccccc;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/contact" style="color: #999999;">Contact Us</a>
+                          </td>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px; border-left: 1px solid #cccccc;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/" style="color: #999999;">About</a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+          `;
           break;
-        case 'Contributor':
+        case "Contributor":
           savedData = await Contributors.create(formData);
+          subject = "Thank You for Applying to GSSoC '24 Extended! 🌟";
+          body = `
+            <body style="padding: 0; margin: 0; background-color: #f1f1f1; width: 100%; height: 100%;">
+  <div style="width: 90%; max-width: 600px; height: auto; background-color: #ffffff; margin: auto; position: relative; overflow: hidden;">
+    <table cellspacing="0" cellpadding="0" width="100%" align="center">
+      <tbody>
+        <tr>
+          <td valign="middle" width="33.33%" align="center" style="padding-top: 20px; padding-bottom: 20px;">
+            <a target="_blank" style="background-color:white;">
+              <img src="https://github.com/user-attachments/assets/62aa7d8e-5eb1-44b2-aaba-5d0c436a2ce7" alt="" width="100%">
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    
+    <div>
+      <img style="width: 100%; height: auto; object-fit: cover;" src="https://github.com/user-attachments/assets/e8a0dfd6-e243-4594-a209-cde2f48d1505" alt="">
+    </div>
+
+    <div style="height: auto; text-align: center; display: flex; flex-direction: column; justify-content: center; padding: 10px;">
+      <h1 style="font-size: 1.8em; color: #515151;">
+        Thank you for applying to be a Campus Ambassador for GSSoC '24 Extended!
+      </h1>
+    </div>
+
+<div style="padding: 20px;">
+  <p style="font-size: 1.1em; color: #848484; font-weight: 400;">
+    Dear ${name},
+    <br/><br/>
+    Thank you for applying to contribute to GSSoC '24 Extended! We are thrilled to have you express interest in joining our community. 🚀
+    <br/><br/>
+We are currently reviewing applications, and you will receive a selection email soon. Stay tuned for further updates and next steps!
+    <br/><br/>
+In the meantime, help spread the word by telling your friends, college peers, and loved ones about this amazing opportunity. Make sure they don't miss out on GSSoC '24 Extended!
+    <br/><br/>
+        👉 Subscribe to our newsletter to stay informed about all the latest updates.<a href="https://gssoc.substack.com/subscribe">Subscribe</a><br/>
+    👉 Connect with our Program Managers for additional guidance and support:
+    <br/><br/>
+    <ul style="padding-left: 20px;">
+      <li><a href="https://www.linkedin.com/in/sanjay-k-v/" style="color: #515151; text-decoration:none; font-weight: bold;">Sanjay KV</a></li>
+      <li><a href="https://www.linkedin.com/in/hemu21/" style="color: #515151; text-decoration:none; font-weight: bold;">Hemanth Kumar</a></li>
+      <li><a href="https://www.linkedin.com/in/mastan-sayyad-126904223/" style="color: #515151; text-decoration:none; font-weight: bold;">Mastan Sayyad</a></li>
+      <li><a href="https://www.linkedin.com/in/radhikamalpani1702/" style="color: #515151; text-decoration:none; font-weight: bold;">Radhika Malpani</a></li>
+      <li><a href="https://www.linkedin.com/in/suhani-singh-paliwal/" style="color: #515151; text-decoration:none; font-weight: bold;">Suhani Singh Paliwal</a></li>
+    </ul>
+  </p>
+</div>
+
+
+    <div style="background-color: #df551a; color: #ffffff; text-align: center; padding: 20px;">
+      <h1 style="font-size: 1.5em; font-weight: bolder; color: #ffffff;">
+        Our Vision for GSSOC'24 Extended
+      </h1>
+      <p style="font-size: 1.2em;">Empowering Developers, Expanding Horizons</p>
+      <p style="font-size: 1em; font-weight: 200; color: #ffffff;">
+        The GSSoC'24 Extended Program offers an additional 30 days of open-source collaboration following the success of GSSoC'24. This extension allows developers to continue learning, contributing, and growing within the open-source community, fostering innovation and engagement.
+      </p>
+    </div>
+    <div style="padding-right: 20px; padding-left:20px;padding-top:20px;padding-bottom:5px;">
+      <p style="font-size: 1.1em; color: #848484; font-weight: 400;">
+      We look forward to having you as a Campus Ambassador, helping us make GSSoC '24 Extended a memorable and impactful event. Your role will be key to inspiring future contributors!<br/>
+      Stay tuned, and thank you for being a part of this amazing initiative!
+      </p>
+      </div>
+    <div style="height: auto; color: #848484; font-size: 1em; text-align: center; padding: 10px;">
+      <h3>
+            <br/>Best regards,<br/>
+            The GSSoC '24 Extended Team
+      </h3>
+    </div>
+
+    <div style="height: 0.5px; background-color: #515151; margin: 20px 0;"></div>
+
+    <table cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td width="600" align="left">
+            <table cellpadding="0" cellspacing="0" width="100%">
+              <tbody>
+                <tr>
+                  <td align="center" style="font-size: 0;">
+                    <table cellpadding="0" cellspacing="0">
+                      <tbody>
+                        <tr>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://x.com/girlscriptsoc?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor">
+                              <img title="X" src="https://enpntus.stripocdn.email/content/assets/img/social-icons/logo-colored/x-logo-colored.png" alt="X" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://www.instagram.com/girlscriptsummerofcode/?hl=en">
+                              <img title="Instagram" src="https://enpntus.stripocdn.email/content/assets/img/social-icons/logo-colored/instagram-logo-colored.png" alt="Instagram" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://github.com/girlscript">
+                              <img title="GitHub" src="https://enpntus.stripocdn.email/content/assets/img/other-icons/logo-colored/github-logo-colored.png" alt="GitHub" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="mailto:gssoc@girlscript.tech">
+                              <img title="Gmail" src="https://enpntus.stripocdn.email/content/assets/img/other-icons/logo-colored/gmail-logo-colored.png" alt="Gmail" width="32">
+                            </a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center">
+                    <p>GSSoC Extd. © 2024, All Rights Reserved.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <table cellpadding="0" cellspacing="0" width="100%">
+                      <tbody>
+                        <tr>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/" style="color: #999999;">Visit Us</a>
+                          </td>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px; border-left: 1px solid #cccccc;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/contact" style="color: #999999;">Contact Us</a>
+                          </td>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px; border-left: 1px solid #cccccc;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/" style="color: #999999;">About</a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+          `;
           break;
-        case 'Mentor':
+        case "Mentor":
           savedData = await Mentor.create(formData);
+          subject =
+            "Thank You for Applying as a Mentor for GSSoC '24 Extended! 🌟";
+          body = `
+             <body style="padding: 0; margin: 0; background-color: #f1f1f1; width: 100%; height: 100%;">
+  <div style="width: 90%; max-width: 600px; height: auto; background-color: #ffffff; margin: auto; position: relative; overflow: hidden;">
+    <table cellspacing="0" cellpadding="0" width="100%" align="center">
+      <tbody>
+        <tr>
+          <td valign="middle" width="33.33%" align="center" style="padding-top: 20px; padding-bottom: 20px;">
+            <a target="_blank" style="background-color:white;">
+              <img src="https://github.com/user-attachments/assets/62aa7d8e-5eb1-44b2-aaba-5d0c436a2ce7" alt="" width="100%">
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    
+    <div>
+      <img style="width: 100%; height: auto; object-fit: cover;" src="https://github.com/user-attachments/assets/e8a0dfd6-e243-4594-a209-cde2f48d1505" alt="">
+    </div>
+
+    <div style="height: auto; text-align: center; display: flex; flex-direction: column; justify-content: center; padding: 10px;">
+      <h1 style="font-size: 1.8em; color: #515151;">
+        Thank you for applying to be a Campus Ambassador for GSSoC '24 Extended!
+      </h1>
+    </div>
+
+<div style="padding: 20px;">
+  <p style="font-size: 1.1em; color: #848484; font-weight: 400;">
+    Dear ${name},
+    <br/><br/>
+   Thank you for applying to be a mentor for GSSoC '24 Extended! We are excited about your interest in guiding the next generation of open-source contributors. 🎉
+    <br/><br/>
+We are currently reviewing mentor applications, and you will receive a confirmation email regarding your selection soon. Stay tuned for more details on the next steps!
+    <br/><br/>
+In the meantime, we encourage you to let your friends, colleagues, and networks know about this incredible opportunity. Let’s work together to inspire and support more contributors in GSSoC '24 Extended!
+    <br/><br/>
+       👉 Subscribe to our newsletter to stay informed about all the latest updates.<a href="https://gssoc.substack.com/subscribe">Subscribe</a><br/>
+    👉 Connect with our Program Managers for additional guidance and support:
+    <br/><br/>
+    <ul style="padding-left: 20px;">
+      <li><a href="https://www.linkedin.com/in/sanjay-k-v/" style="color: #515151; text-decoration:none; font-weight: bold;">Sanjay KV</a></li>
+      <li><a href="https://www.linkedin.com/in/hemu21/" style="color: #515151; text-decoration:none; font-weight: bold;">Hemanth Kumar</a></li>
+      <li><a href="https://www.linkedin.com/in/mastan-sayyad-126904223/" style="color: #515151; text-decoration:none; font-weight: bold;">Mastan Sayyad</a></li>
+      <li><a href="https://www.linkedin.com/in/radhikamalpani1702/" style="color: #515151; text-decoration:none; font-weight: bold;">Radhika Malpani</a></li>
+      <li><a href="https://www.linkedin.com/in/suhani-singh-paliwal/" style="color: #515151; text-decoration:none; font-weight: bold;">Suhani Singh Paliwal</a></li>
+    </ul>
+  </p>
+</div>
+
+
+    <div style="background-color: #df551a; color: #ffffff; text-align: center; padding: 20px;">
+      <h1 style="font-size: 1.5em; font-weight: bolder; color: #ffffff;">
+        Our Vision for GSSOC'24 Extended
+      </h1>
+      <p style="font-size: 1.2em;">Empowering Developers, Expanding Horizons</p>
+      <p style="font-size: 1em; font-weight: 200; color: #ffffff;">
+        The GSSoC'24 Extended Program offers an additional 30 days of open-source collaboration following the success of GSSoC'24. This extension allows developers to continue learning, contributing, and growing within the open-source community, fostering innovation and engagement.
+      </p>
+    </div>
+    <div style="padding-right: 20px; padding-left:20px;padding-top:20px;padding-bottom:5px;">
+      <p style="font-size: 1.1em; color: #848484; font-weight: 400;">
+      We look forward to having you as a Campus Ambassador, helping us make GSSoC '24 Extended a memorable and impactful event. Your role will be key to inspiring future contributors!<br/>
+      Stay tuned, and thank you for being a part of this amazing initiative!
+      </p>
+      </div>
+    <div style="height: auto; color: #848484; font-size: 1em; text-align: center; padding: 10px;">
+      <h3>
+            <br/>Best regards,<br/>
+            The GSSoC '24 Extended Team
+      </h3>
+    </div>
+
+    <div style="height: 0.5px; background-color: #515151; margin: 20px 0;"></div>
+
+    <table cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td width="600" align="left">
+            <table cellpadding="0" cellspacing="0" width="100%">
+              <tbody>
+                <tr>
+                  <td align="center" style="font-size: 0;">
+                    <table cellpadding="0" cellspacing="0">
+                      <tbody>
+                        <tr>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://x.com/girlscriptsoc?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor">
+                              <img title="X" src="https://enpntus.stripocdn.email/content/assets/img/social-icons/logo-colored/x-logo-colored.png" alt="X" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://www.instagram.com/girlscriptsummerofcode/?hl=en">
+                              <img title="Instagram" src="https://enpntus.stripocdn.email/content/assets/img/social-icons/logo-colored/instagram-logo-colored.png" alt="Instagram" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://github.com/girlscript">
+                              <img title="GitHub" src="https://enpntus.stripocdn.email/content/assets/img/other-icons/logo-colored/github-logo-colored.png" alt="GitHub" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="mailto:gssoc@girlscript.tech">
+                              <img title="Gmail" src="https://enpntus.stripocdn.email/content/assets/img/other-icons/logo-colored/gmail-logo-colored.png" alt="Gmail" width="32">
+                            </a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center">
+                    <p>GSSoC Extd. © 2024, All Rights Reserved.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <table cellpadding="0" cellspacing="0" width="100%">
+                      <tbody>
+                        <tr>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/" style="color: #999999;">Visit Us</a>
+                          </td>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px; border-left: 1px solid #cccccc;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/contact" style="color: #999999;">Contact Us</a>
+                          </td>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px; border-left: 1px solid #cccccc;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/" style="color: #999999;">About</a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+          `;
           break;
-        case 'ProjectAdmin':
+        case "ProjectAdmin":
           savedData = await ProjectAdmin.create(formData);
+          subject =
+            "Thank You for Applying as a Project Admin and Submitting Your Project for GSSoC '24 Extended! 🌟";
+          body = `
+                        <body style="padding: 0; margin: 0; background-color: #f1f1f1; width: 100%; height: 100%;">
+  <div style="width: 90%; max-width: 600px; height: auto; background-color: #ffffff; margin: auto; position: relative; overflow: hidden;">
+    <table cellspacing="0" cellpadding="0" width="100%" align="center">
+      <tbody>
+        <tr>
+          <td valign="middle" width="33.33%" align="center" style="padding-top: 20px; padding-bottom: 20px;">
+            <a target="_blank" style="background-color:white;">
+              <img src="https://github.com/user-attachments/assets/62aa7d8e-5eb1-44b2-aaba-5d0c436a2ce7" alt="" width="100%">
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    
+    <div>
+      <img style="width: 100%; height: auto; object-fit: cover;" src="https://github.com/user-attachments/assets/e8a0dfd6-e243-4594-a209-cde2f48d1505" alt="">
+    </div>
+
+    <div style="height: auto; text-align: center; display: flex; flex-direction: column; justify-content: center; padding: 10px;">
+      <h1 style="font-size: 1.8em; color: #515151;">
+        Thank you for applying to be a Campus Ambassador for GSSoC '24 Extended!
+      </h1>
+    </div>
+
+<div style="padding: 20px;">
+  <p style="font-size: 1.1em; color: #848484; font-weight: 400;">
+    Dear ${name},
+    <br/><br/>
+   Thank you for submitting your project to GSSoC '24 Extended! We truly appreciate your willingness to mentor contributors and share your project with the open-source community. 🚀
+    <br/><br/>
+We are currently reviewing the projects, and you will receive a confirmation email soon with further details regarding the next steps and timelines. We are excited to collaborate with you to create a valuable learning experience for our contributors!
+    <br/><br/>
+In the meantime, feel free to encourage your community to join GSSoC '24 Extended by sharing the opportunity with friends, colleagues, and fellow developers.
+    <br/><br/>
+        👉 Subscribe to our newsletter to stay informed about all the latest updates.<a href="https://gssoc.substack.com/subscribe">Subscribe</a><br/>
+    👉 Connect with our Program Managers for additional guidance and support:
+    <br/><br/>
+    <ul style="padding-left: 20px;">
+      <li><a href="https://www.linkedin.com/in/sanjay-k-v/" style="color: #515151; text-decoration:none; font-weight: bold;">Sanjay KV</a></li>
+      <li><a href="https://www.linkedin.com/in/hemu21/" style="color: #515151; text-decoration:none; font-weight: bold;">Hemanth Kumar</a></li>
+      <li><a href="https://www.linkedin.com/in/mastan-sayyad-126904223/" style="color: #515151; text-decoration:none; font-weight: bold;">Mastan Sayyad</a></li>
+      <li><a href="https://www.linkedin.com/in/radhikamalpani1702/" style="color: #515151; text-decoration:none; font-weight: bold;">Radhika Malpani</a></li>
+      <li><a href="https://www.linkedin.com/in/suhani-singh-paliwal/" style="color: #515151; text-decoration:none; font-weight: bold;">Suhani Singh Paliwal</a></li>
+    </ul>
+  </p>
+</div>
+
+
+    <div style="background-color: #df551a; color: #ffffff; text-align: center; padding: 20px;">
+      <h1 style="font-size: 1.5em; font-weight: bolder; color: #ffffff;">
+        Our Vision for GSSOC'24 Extended
+      </h1>
+      <p style="font-size: 1.2em;">Empowering Developers, Expanding Horizons</p>
+      <p style="font-size: 1em; font-weight: 200; color: #ffffff;">
+        The GSSoC'24 Extended Program offers an additional 30 days of open-source collaboration following the success of GSSoC'24. This extension allows developers to continue learning, contributing, and growing within the open-source community, fostering innovation and engagement.
+      </p>
+    </div>
+    <div style="padding-right: 20px; padding-left:20px;padding-top:20px;padding-bottom:5px;">
+      <p style="font-size: 1.1em; color: #848484; font-weight: 400;">
+      We look forward to having you as a Campus Ambassador, helping us make GSSoC '24 Extended a memorable and impactful event. Your role will be key to inspiring future contributors!<br/>
+      Stay tuned, and thank you for being a part of this amazing initiative!
+      </p>
+      </div>
+    <div style="height: auto; color: #848484; font-size: 1em; text-align: center; padding: 10px;">
+      <h3>
+            <br/>Best regards,<br/>
+            The GSSoC '24 Extended Team
+      </h3>
+    </div>
+
+    <div style="height: 0.5px; background-color: #515151; margin: 20px 0;"></div>
+
+    <table cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td width="600" align="left">
+            <table cellpadding="0" cellspacing="0" width="100%">
+              <tbody>
+                <tr>
+                  <td align="center" style="font-size: 0;">
+                    <table cellpadding="0" cellspacing="0">
+                      <tbody>
+                        <tr>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://x.com/girlscriptsoc?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor">
+                              <img title="X" src="https://enpntus.stripocdn.email/content/assets/img/social-icons/logo-colored/x-logo-colored.png" alt="X" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://www.instagram.com/girlscriptsummerofcode/?hl=en">
+                              <img title="Instagram" src="https://enpntus.stripocdn.email/content/assets/img/social-icons/logo-colored/instagram-logo-colored.png" alt="Instagram" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="https://github.com/girlscript">
+                              <img title="GitHub" src="https://enpntus.stripocdn.email/content/assets/img/other-icons/logo-colored/github-logo-colored.png" alt="GitHub" width="32">
+                            </a>
+                          </td>
+                          <td align="center" valign="top">
+                            <a target="_blank" href="mailto:gssoc@girlscript.tech">
+                              <img title="Gmail" src="https://enpntus.stripocdn.email/content/assets/img/other-icons/logo-colored/gmail-logo-colored.png" alt="Gmail" width="32">
+                            </a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center">
+                    <p>GSSoC Extd. © 2024, All Rights Reserved.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <table cellpadding="0" cellspacing="0" width="100%">
+                      <tbody>
+                        <tr>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/" style="color: #999999;">Visit Us</a>
+                          </td>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px; border-left: 1px solid #cccccc;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/contact" style="color: #999999;">Contact Us</a>
+                          </td>
+                          <td align="center" valign="top" width="33.33%" style="padding-top: 5px; padding-bottom: 5px; border-left: 1px solid #cccccc;">
+                            <a target="_blank" href="https://gssoc.girlscript.tech/" style="color: #999999;">About</a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+          `;
           break;
         default:
-          return res.status(400).json({ success: false, message: 'Invalid role' });
+          return res
+            .status(400)
+            .json({ success: false, message: "Invalid role" });
       }
+
+      await sendEmail(email, subject, body);
 
       return res.status(201).json({ success: true, data: savedData });
     } catch (error) {
-      console.error('Error saving data:', error.message);
+      console.error("Error saving data:", error.message);
       return res.status(400).json({ success: false, error: error.message });
     }
   } else {
     console.error(`Method ${method} not allowed`);
-    return res.status(405).json({ success: false, message: 'Method not allowed' });
+    return res
+      .status(405)
+      .json({ success: false, message: "Method not allowed" });
   }
 }
+
+async function sendEmail(recipient, subject, message) {
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_APP_PASS,
+    },
+    tls: {
+      rejectUnauthorized: false,
+    },
+  });
+
+  const mailOptions = {
+    from: process.env.EMAIL_USER,
+    to: recipient,
+    subject: subject,
+    html: message,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Email sent to ${recipient}`);
+  } catch (error) {
+    console.error("Error sending email:", error.message);
+    throw new Error("Email sending failed");
+  }
+}
+
+export default allowCors(handler);

--- a/pages/registration.js
+++ b/pages/registration.js
@@ -117,7 +117,7 @@ const Registration = () => {
       setSelectedTimer(paTimeLeft);
     }
   }, [caTimeLeft]);
-  const caTargetDate = new Date(2024, 8, 11, 18, 0, 0);
+  const caTargetDate = new Date(2024, 8, 13, 18, 0, 0);
   const paTargetDate = new Date(2024, 8, 15, 18, 0, 0);
   const contributorTargetDate = new Date(2024, 8, 14, 18, 0, 0);
   const mentorTargetDate = new Date(2024, 8, 15, 18, 0, 0);

--- a/pages/registration.js
+++ b/pages/registration.js
@@ -117,7 +117,7 @@ const Registration = () => {
       setSelectedTimer(paTimeLeft);
     }
   }, [caTimeLeft]);
-  const caTargetDate = new Date(2024, 8, 13, 18, 0, 0);
+  const caTargetDate = new Date(2024, 8, 11, 18, 0, 0);
   const paTargetDate = new Date(2024, 8, 15, 18, 0, 0);
   const contributorTargetDate = new Date(2024, 8, 14, 18, 0, 0);
   const mentorTargetDate = new Date(2024, 8, 15, 18, 0, 0);
@@ -452,7 +452,7 @@ const Registration = () => {
                   </span>{" "}
                   Registrations for{" "}
                   <span className="font-bold text-[#f57d33]">{role}</span>{" "}
-                  haven't opened yet. Stay tuned, and check back soon for
+                  haven&apos;t opened yet. Stay tuned, and check back soon for
                   updates.
                 </h1>
                 <div>
@@ -573,7 +573,7 @@ const Registration = () => {
             </div>
             <div className="min-h-screen p-10 max-sm:p-2 max-sm:my-10 w-full flex flex-col items-center justify-center z-30">
               <h1 className="text-2xl font-semibold text-center mb-6">
-                REGISTER FOR GSSOC' EXTD.
+                REGISTER FOR GSSOC&apos; EXTD.
               </h1>
               <div className="max-w-5xl w-full">
                 <div className="my-2 font-medium">PERSONAL DETAILS</div>

--- a/pages/registration.js
+++ b/pages/registration.js
@@ -8,6 +8,61 @@ import PhoneInput from "react-phone-input-2";
 import "react-phone-input-2/lib/style.css";
 import Head from "next/head";
 
+const UploadField = ({ name, label, onChange, preview, setuploadedFile }) => {
+  const [file, setFile] = useState(null);
+  const [error, setError] = useState('');
+  const [isUploaded, setIsUploaded] = useState(false);
+
+  const handleChange = (event) => {
+    const selectedFile = event.target.files[0];
+    if (selectedFile) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        const base64Url = reader.result;
+        setFile(base64Url);
+        setError('');
+        setIsUploaded(true);
+        setuploadedFile(base64Url);
+        onChange(event); 
+      };
+      reader.readAsDataURL(selectedFile);
+    }
+  };
+
+  return (
+    <div className="upload-field">
+      <label
+        htmlFor={name}
+        className="bg-[#F86F26] px-4 rounded-lg py-2 cursor-pointer text-white font-semibold"
+      >
+        {isUploaded ? 'Uploaded' : label}
+      </label>
+      <input
+        type="file"
+        id={name}
+        name={name}
+        onChange={handleChange}
+        className="hidden"
+      />
+      {error && <p className="error">{error}</p>}
+      {file && (
+        <a
+          href={file}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mx-4"
+        >
+          {preview ? (
+            <embed src={file} type="application/pdf" width="600" height="400" />
+          ) : (
+            'View File'
+          )}
+        </a>
+      )}
+    </div>
+  );
+};
+
 const Registration = () => {
   const [role, setRole] = useState("");
   const [formData, setFormData] = useState({});
@@ -52,20 +107,27 @@ const Registration = () => {
   });
   const [isTimeUp, setIsTimeUp] = useState(false);
   useEffect(() => {
-    setSelectedTimer(caTimeLeft);
+    if (role == "") {
+      setSelectedTimer(caTimeLeft);
+    } else if (role == "Contributor") {
+      setSelectedTimer(contributorTimeLeft);
+    } else if (role == "Mentor") {
+      setSelectedTimer(mentorTimeLeft);
+    } else if (role == "ProjectAdmin") {
+      setSelectedTimer(paTimeLeft);
+    }
   }, [caTimeLeft]);
-  const caTargetDate = new Date(2024, 8, 13, 18, 30, 0);
-  const paTargetDate = new Date(2024, 8, 15, 18, 30, 0);
-  const contributorTargetDate = new Date(2024, 8, 14, 18, 30, 0);
-  const mentorTargetDate = new Date(2024, 8, 15, 18, 30, 0);
-
+  const caTargetDate = new Date(2024, 8, 13, 18, 0, 0);
+  const paTargetDate = new Date(2024, 8, 15, 18, 0, 0);
+  const contributorTargetDate = new Date(2024, 8, 14, 18, 0, 0);
+  const mentorTargetDate = new Date(2024, 8, 15, 18, 0, 0);
   useEffect(() => {
     const interval = setInterval(() => {
       const now = new Date();
 
       const calculateTimeLeft = (target) => {
         const distance = target - now;
-          if (distance < 0) return { hours: "00", minutes: "00",seconds:"00" };
+        if (distance < 0) return { hours: "00", minutes: "00", seconds: "00" };
 
         const totalHours = String(
           Math.floor(distance / (1000 * 60 * 60))
@@ -141,7 +203,6 @@ const Registration = () => {
   const handleBack = () => {
     setCurrentStep(currentStep - 1);
   };
-
   const handleRoleChange = (e) => {
     setRole(e.target.value);
     setFormData({});
@@ -181,7 +242,6 @@ const Registration = () => {
       });
     }
   };
-
   const handlePhoneChange = (value, countryData) => {
     const formattedPhone = `+${countryData.dialCode} ${value.slice(
       countryData.dialCode.length
@@ -202,12 +262,31 @@ const Registration = () => {
       newErrors.collegeOrOffice = "College/Office is required.";
     if (!formData.gender) newErrors.gender = "Gender is required.";
     if (!formData.year) newErrors.year = "Year is required.";
-    if (!formData.state) newErrors.state = "State is required.";
-    if (!formData.country) newErrors.country = "Country is required.";
     if (!formData.gitHubProfileUrl)
       newErrors.gitHubProfileUrl = "Github Profile is required.";
     if (!formData.discordUsername)
       newErrors.discordUsername = "Discord username is required.";
+    if (!formData.linkedInProfileUrl)
+      newErrors.linkedInProfileUrl = "Linkedin Profile is required.";
+    if (!formData.phoneNumber)
+      newErrors.phoneNumber = "phoneNumber is Required";
+    if (formData.phoneNumber == "+91")
+      newErrors.phoneNumber = "phoneNumber is Required";
+    if (role === "ProjectAdmin") {
+      if (!formData.projectName)
+        newErrors.projectName = "Project Name is Required";
+      if (!formData.techStacks) newErrors.techStacks = "Tech Stack is Required";
+      if (!formData.repositoryUrl)
+        newErrors.repositoryUrl = "Repository URL is Required";
+      if (!formData.projectDescription)
+        newErrors.projectDescription = "Project Description is Required";
+    }
+    if (role != "ProjectAdmin") {
+      if (!formData.reason) newErrors.reason = "Reason is Required";
+    }
+    if (role === "Mentor") {
+      if (!formData.techStacks) newErrors.techStacks = "Tech Stack is Required";
+    }
 
     if (!validateEmail(formData.email)) {
       newErrors.email = "Please enter a valid email address.";
@@ -242,10 +321,7 @@ const Registration = () => {
     delete finalData.lastName;
 
     try {
-      const response = await axios.post(
-        "https://gssoc-website-new-lovat.vercel.app/api/registration",
-        finalData
-      );
+      const response = await axios.post("https://gssoc-website-new-lovat.vercel.app/api/registration", finalData);
     } catch (error) {
       console.error("Error submitting form:", error);
       alert("Error registering. Please try again.");
@@ -265,6 +341,19 @@ const Registration = () => {
     ...selectedTimer.minutes.split(""),
     ...selectedTimer.seconds.split(""),
   ];
+  const [uploadedFile,setuploadedFile] = useState("")
+  useEffect(() => {
+    if (uploadedFile) {
+      setFormData({
+        ...formData,
+        resumeUpload: uploadedFile,
+      });
+    }
+  }, [uploadedFile]);
+  const handleFileChange = (e) => {
+    console.log("")
+  };
+  
   const renderForm = () => {
     switch (currentStep) {
       case 1:
@@ -356,28 +445,47 @@ const Registration = () => {
               </div>
             )}
             {role !== "CA" && role !== "" && isNext && (
-              <div className="flex gap-6 max-sm:gap-3 max-sm:mt-20 items-center">
-                {timerDigits.map((digit, index) => (
-                  <div
-                    className="flex justify-center items-center gap-4"
-                    key={index}
-                  >
-                    <div className="relative">
-                      <div className="bg-[#f57d33] w-24 h-24 max-sm:w-16 max-sm:h-16 border-[#f57d33] z-20 border-2 rounded-xl flex items-center justify-center"></div>
-                      <div className="bg-white absolute bottom-2 right-2 z-10 w-24 h-24 max-sm:w-16 max-sm:h-16 border-[#f57d33] border-2 rounded-xl">
-                        <span className="text-black text-2xl font-bold flex justify-center items-center h-full">
-                          {digit}
-                        </span>
+              <div>
+                <h1 className="text-2xl font-normal text-center mt-20 mb-16 w-full max-w-3xl mx-auto">
+                  <span className="font-bold text-[#f57d33]">
+                    Please Wait !
+                  </span>{" "}
+                  Registrations for{" "}
+                  <span className="font-bold text-[#f57d33]">{role}</span>{" "}
+                  haven't opened yet. Stay tuned, and check back soon for
+                  updates.
+                </h1>
+                <div>
+                  <div className="flex gap-6 max-sm:gap-3 max-sm:mt-20 items-center">
+                    {timerDigits.map((digit, index) => (
+                      <div
+                        className="flex justify-center items-center gap-4"
+                        key={index}
+                      >
+                        <div className="relative">
+                          <div className="bg-[#f57d33] w-24 h-24 max-sm:w-16 max-sm:h-16 border-[#f57d33] z-20 border-2 rounded-xl flex items-center justify-center"></div>
+                          <div className="bg-white absolute bottom-2 right-2 z-10 w-24 h-24 max-sm:w-16 max-sm:h-16 border-[#f57d33] border-2 rounded-xl">
+                            <span className="text-black text-2xl font-bold flex justify-center items-center h-full">
+                              {digit}
+                            </span>
+                          </div>
+                        </div>
+                        {index % 2 !== 0 &&
+                          index !== timerDigits.length - 1 && (
+                            <div className="flex flex-col gap-4">
+                              <div className="bg-[#f57d33] w-4 h-4 max-sm:w-3 max-sm:h-3 rounded-full"></div>
+                              <div className="bg-[#f57d33] w-4 h-4 max-sm:w-3 max-sm:h-3 rounded-full"></div>
+                            </div>
+                          )}
                       </div>
-                    </div>
-                    {index % 2 !== 0 && index !== timerDigits.length - 1 && (
-                      <div className="flex flex-col gap-4">
-                        <div className="bg-[#f57d33] w-4 h-4 max-sm:w-3 max-sm:h-3 rounded-full"></div>
-                        <div className="bg-[#f57d33] w-4 h-4 max-sm:w-3 max-sm:h-3 rounded-full"></div>
-                      </div>
-                    )}
+                    ))}
                   </div>
-                ))}
+                  <div className="text-center flex justify-around items-center w-full mt-6 max-w-3xl m-auto font-normal text-[#676767] text-2xl">
+                    <span>Hours</span>
+                    <span>Mins</span>
+                    <span>Seconds</span>
+                  </div>
+                </div>
               </div>
             )}
             {isRegistrationsOpen && (
@@ -465,7 +573,7 @@ const Registration = () => {
             </div>
             <div className="min-h-screen p-10 max-sm:p-2 max-sm:my-10 w-full flex flex-col items-center justify-center z-30">
               <h1 className="text-2xl font-semibold text-center mb-6">
-                REGISTER FOR GSSOC&apos24 EXTD.
+                REGISTER FOR GSSOC' EXTD.
               </h1>
               <div className="max-w-5xl w-full">
                 <div className="my-2 font-medium">PERSONAL DETAILS</div>
@@ -606,7 +714,9 @@ const Registration = () => {
                         />
 
                         {errors.phoneNumber && (
-                          <span className="error">{errors.phoneNumber}</span>
+                          <span className="mt-1 text-xs text-red-600">
+                            {errors.phoneNumber}
+                          </span>
                         )}
                       </div>
                     </div>
@@ -624,7 +734,6 @@ const Registration = () => {
                         value={formData.linkedInProfileUrl}
                         handleChange={handleInputChange}
                         error={errors.linkedInProfileUrl}
-                        required={true}
                       />
                       <InputField
                         label="Discord Username"
@@ -682,44 +791,292 @@ const Registration = () => {
               </div>
             </div>
 
-            <div className="min-h-screen p-6 md:p-10 bg-gray-100 flex flex-col items-center justify-center">
+            <div className="min-h-screen w-full p-6 md:p-10 bg-gray-100 flex flex-col items-center justify-center">
               <h1 className="text-2xl md:text-3xl font-medium text-center mb-8 md:mb-12 z-20">
-                BECOME A CAMPUS AMBASSADOR
+                {role === "CA"
+                  ? "BECOME A CAMPUS AMBASSADOR"
+                  : role === "Contributor"
+                  ? "BECOME A CONTRIBUTOR"
+                  : role === "ProjectAdmin"
+                  ? "BECOME A PROJECT ADMIN"
+                  : "BECOME A MENTOR"}
               </h1>
 
-              <div className="flex flex-col md:flex-row items-center">
+              <div className="flex flex-col justify-center w-full md:flex-row items-center">
                 <div className="w-72 h-72 md:w-96 md:h-[450px] z-30 my-12">
-                  <img
-                    src="https://github.com/user-attachments/assets/451e5965-5142-4b13-bcfe-95ce77f7cd36"
-                    alt="Banner"
-                  />
+                  {role === "CA" && (
+                    <img
+                      src="https://github.com/user-attachments/assets/451e5965-5142-4b13-bcfe-95ce77f7cd36"
+                      alt="Banner"
+                    />
+                  )}
+                  {role === "Contributor" && (
+                    <img
+                      src="https://github.com/user-attachments/assets/b5b1f992-aaeb-408c-a795-a81e9623c45f"
+                      alt="Banner"
+                    />
+                  )}
+                  {role === "ProjectAdmin" && (
+                    <img
+                      src="https://github.com/user-attachments/assets/39f7fd52-a14e-47ea-811b-8a3e3f3132ed"
+                      alt="Banner"
+                    />
+                  )}
+                  {role === "Mentor" && (
+                    <img
+                      src="https://github.com/user-attachments/assets/5f4cf256-1ce4-4712-a353-ba28cb25b2ed"
+                      alt="Banner"
+                    />
+                  )}
                 </div>
 
                 <div className="p-4 md:p-8 max-w-lg md:max-w-3xl w-full z-10">
-                  <h1 className="text-xl md:text-2xl font-semibold text-center mb-4 md:mb-6"></h1>
+                  {role === "CA" && (
+                    <>
+                      <TextAreaField
+                        label="WHY DO YOU WISH TO BECOME A CAMPUS AMBASSADOR?"
+                        name="reason"
+                        handleChange={handleInputChange}
+                        error={errors.reason}
+                      />
 
-                  <TextAreaField
-                    label="WHY DO YOU WISH TO BECOME A CAMPUS AMBASSADOR?"
-                    name="reason"
-                    handleChange={handleInputChange}
-                    error={errors.reason}
-                  />
+                      <TextAreaField
+                        label="DO YOU HAVE ANY PAST EXPERIENCE AS A CAMPUS AMBASSADOR? 
+                  SHARE YOUR EXPERIENCE BRIEFLY"
+                        name="partOfProgramBefore"
+                        handleChange={handleInputChange}
+                        error={errors.partOfProgramBefore}
+                        required={false}
+                      />
 
-                  <TextAreaField
-                    label="DO YOU HAVE ANY PAST EXPERIENCE AS A CAMPUS AMBASSADOR? 
-                      SHARE YOUR EXPERIENCE BRIEFLY"
-                    name="partOfProgramBefore"
-                    handleChange={handleInputChange}
-                    error={errors.partOfProgramBefore}
-                  />
+                      <InputField
+                        label="REFERRAL CODE (Optional)"
+                        name="referral"
+                        handleChange={handleInputChange}
+                        error={errors.referral}
+                        required={false}
+                      />
+                      <SelectField
+                        label="DO YOU HAVE A STARTUP AND ARE SEEKING SERVICES? SELECT 'YES' TO RECEIVE FUTURE BULDER.AI UPDATES (OPTIONAL)"
+                        name="startupServices"
+                        options={["", "YES", "NO"]}
+                        handleChange={handleInputChange}
+                        error={errors.startupServices}
+                        required={false}
+                      />
+                      {formData.gender && formData.gender === "Female" && (
+                        <div className="mb-4">
+                          <div className="block text-sm font-semibold text-gray-800 mb-4">
+                            IF YOU WISH TO HAVE YOUR RESUME SHARED WITH
+                            COMPANIES, PLEASE UPLOAD YOUR RESUME (OPTIONAL)
+                          </div>
+                          <UploadField
+                            name="resume"
+                            label="Upload Resume"
+                            onChange={handleFileChange}
+                            preview={false}
+                            setuploadedFile={setuploadedFile}
+                          />
+                        </div>
+                      )}
+                    </>
+                  )}
 
-                  <InputField
-                    label="REFERRAL CODE (Optional)"
-                    name="referral"
-                    handleChange={handleInputChange}
-                    error={errors.referral}
-                    required={false}
-                  />
+                  {role === "Contributor" && (
+                    <>
+                      <TextAreaField
+                        label="WHY DO YOU WISH TO BECOME A CONTRIBUTOR?"
+                        name="reason"
+                        handleChange={handleInputChange}
+                        error={errors.reason}
+                      />
+                      <InputField
+                        label="DO YOU HAVE ANY PAST EXPERIENCE AS AN OPEN-SOURCE CONTRIBUTOR 
+SHARE YOUR EXPERIENCE BRIEFLY"
+                        name="partOfProgramBefore"
+                        handleChange={handleInputChange}
+                        error={errors.partOfProgramBefore}
+                        required={false}
+                      />
+                      <InputField
+                        label="REFERRAL CODE (Optional)"
+                        name="referral"
+                        handleChange={handleInputChange}
+                        error={errors.referral}
+                        required={false}
+                      />
+                      <SelectField
+                        label="DO YOU HAVE A STARTUP AND ARE SEEKING SERVICES? SELECT 'YES' TO RECEIVE FUTURE BULDER.AI UPDATES (OPTIONAL)"
+                        name="startupServices"
+                        options={["", "YES", "NO"]}
+                        handleChange={handleInputChange}
+                        error={errors.startupServices}
+                        required={false}
+                      />
+                      {formData.gender && formData.gender === "Female" && (
+                        <div className="mb-4">
+                          <div className="block text-sm font-semibold text-gray-800 mb-4">
+                            IF YOU WISH TO HAVE YOUR RESUME SHARED WITH
+                            COMPANIES, PLEASE UPLOAD YOUR RESUME (OPTIONAL)
+                          </div>
+                          <UploadField
+                            name="resume"
+                            label="Upload Resume"
+                            onChange={handleFileChange}
+                            preview={false}
+                          />
+                        </div>
+                      )}
+                    </>
+                  )}
+
+                  {role === "ProjectAdmin" && (
+                    <>
+                      <div className="flex gap-10">
+                        <InputField
+                          label="NAME OF THE PROJECT"
+                          name="projectName"
+                          handleChange={handleInputChange}
+                          error={errors.projectName}
+                          gap={"mb-2"}
+                          required={true}
+                        />
+                        <InputField
+                          label="TECHSTACK"
+                          name="techStacks"
+                          handleChange={handleInputChange}
+                          error={errors.techStacks}
+                          gap={"mb-2"}
+                          required={true}
+                        />
+                      </div>
+                      <div className="flex gap-10">
+                        <InputField
+                          label="NAME OF THE ORGANIZATION"
+                          name="organisationName"
+                          handleChange={handleInputChange}
+                          error={errors.organisationName}
+                          required={false}
+                          gap={"mb-2"}
+                        />
+                        <InputField
+                          label="REPOSITORY URL"
+                          name="repositoryUrl"
+                          handleChange={handleInputChange}
+                          error={errors.repositoryUrl}
+                          gap={"mb-2"}
+                          required={true}
+                        />
+                      </div>
+                      <InputField
+                        label="PROJECT DESCRIPTION"
+                        name="projectDescription"
+                        handleChange={handleInputChange}
+                        error={errors.projectDescription}
+                        gap={"mb-2"}
+                        required={true}
+                      />
+                      <InputField
+                        label="ORGANISATION DESCRIPTION"
+                        name="organistationDescription"
+                        handleChange={handleInputChange}
+                        error={errors.organistationDescription}
+                        required={false}
+                        gap={"mb-2"}
+                      />
+                      <InputField
+                        label="DEPLOYMENT LINK"
+                        name="deploymentLink"
+                        handleChange={handleInputChange}
+                        error={errors.deploymentLink}
+                        required={false}
+                        gap={"mb-2"}
+                      />
+                      <InputField
+                        label="EXPECTED NUMBER OF MENTORS REQUIRED"
+                        name="expectedMentors"
+                        handleChange={handleInputChange}
+                        error={errors.expectedMentors}
+                        required={false}
+                        gap={"mb-2"}
+                      />
+                      <InputField
+                        label="REFERRAL CODE"
+                        name="referral"
+                        handleChange={handleInputChange}
+                        error={errors.referral}
+                        required={false}
+                        gap={"mb-2"}
+                      />
+                      <SelectField
+                        label="DO YOU HAVE A STARTUP AND ARE SEEKING SERVICES? SELECT 'YES' TO RECEIVE FUTURE BULDER.AI UPDATES (OPTIONAL)"
+                        name="startupServices"
+                        options={["", "YES", "NO"]}
+                        handleChange={handleInputChange}
+                        error={errors.startupServices}
+                        required={false}
+                      />
+                      {formData.gender && formData.gender === "Female" && (
+                        <div className="mb-4">
+                          <div className="block text-sm font-semibold text-gray-800 mb-4">
+                            IF YOU WISH TO HAVE YOUR RESUME SHARED WITH
+                            COMPANIES, PLEASE UPLOAD YOUR RESUME (OPTIONAL)
+                          </div>
+                          <UploadField
+                            name="resume"
+                            label="Upload Resume"
+                            onChange={handleFileChange}
+                            preview={false}
+                          />
+                        </div>
+                      )}
+                    </>
+                  )}
+                  {role === "Mentor" && (
+                    <>
+                      <TextAreaField
+                        label="BRIEFLY, EXPLAIN YOUR TECH-STACK, AND YOUR EXPERTISE."
+                        name="techStacks"
+                        handleChange={handleInputChange}
+                        error={errors.techStacks}
+                      />
+                      <InputField
+                        label="WHY DO YOU WISH TO BECOME A GSSOC MENTOR?"
+                        name="reason"
+                        handleChange={handleInputChange}
+                        error={errors.reason}
+                      />
+                      <InputField
+                        label="REFERRAL CODE (Optional)"
+                        name="referral"
+                        handleChange={handleInputChange}
+                        error={errors.referral}
+                        required={false}
+                      />
+                      <SelectField
+                        label="DO YOU HAVE A STARTUP AND ARE SEEKING SERVICES? SELECT 'YES' TO RECEIVE FUTURE BULDER.AI UPDATES (OPTIONAL)"
+                        name="startupServices"
+                        options={["", "YES", "NO"]}
+                        handleChange={handleInputChange}
+                        error={errors.startupServices}
+                        required={false}
+                      />
+                      {formData.gender && formData.gender === "Female" && (
+                        <div className="mb-4">
+                          <div className="block text-sm font-semibold text-gray-800 mb-4">
+                            IF YOU WISH TO HAVE YOUR RESUME SHARED WITH
+                            COMPANIES, PLEASE UPLOAD YOUR RESUME (OPTIONAL)
+                          </div>
+                          <UploadField
+                            name="resume"
+                            label="Upload Resume"
+                            onChange={handleFileChange}
+                            preview={false}
+                          />
+                        </div>
+                      )}
+                    </>
+                  )}
 
                   <div className="flex flex-col md:flex-row gap-4 md:gap-8 justify-end">
                     <button
@@ -753,8 +1110,8 @@ const Registration = () => {
     <>
       <Head>
         <title>
-          Register | GirlScript Summer of Code 2024 | GirlScript
-          Foundation India
+          Register | GirlScript Summer of Code 2024 | GirlScript Foundation
+          India
         </title>
         <meta
           name="description"
@@ -806,8 +1163,9 @@ const InputField = ({
   error,
   value,
   required = true,
+  gap = "mb-6",
 }) => (
-  <div className="mb-6 w-full">
+  <div className={`${gap} w-full`}>
     <label
       htmlFor={name}
       className="block text-sm font-semibold text-gray-800 mb-2"
@@ -849,6 +1207,7 @@ InputField.propTypes = {
   handleChange: PropTypes.func,
   error: PropTypes.string,
 };
+
 const SelectField = ({
   label,
   name,

--- a/utils/models/caSchema.js
+++ b/utils/models/caSchema.js
@@ -48,12 +48,10 @@ const caSchema = new mongoose.Schema({
   },
   country: {
     type: String,
-    required: true,
     trim: true
   },
   state: {
     type: String,
-    required: true,
     trim: true
   },
   city: {
@@ -76,8 +74,17 @@ const caSchema = new mongoose.Schema({
   },
   reason: {
     type: String,
-    required: true,
+    required:true,
     trim: true
+  },
+  resumeUpload: {
+    type: String,
+    trim: true
+  },
+  startupServices: {
+    type: String,
+    enum: ['', 'YES', 'NO'],
+    default: ''
   },
 }, { timestamps: true });
 

--- a/utils/models/contributorsSchema.js
+++ b/utils/models/contributorsSchema.js
@@ -28,7 +28,7 @@ const contributorsSchema = new mongoose.Schema({
     required: true,
     trim: true
   },
-  referralCode: {
+  referral: {
     type: String,
     trim: true
   },
@@ -39,6 +39,7 @@ const contributorsSchema = new mongoose.Schema({
   },
   linkedInProfileUrl: {
     type: String,
+    required: true,
     trim: true
   },
   discordUsername: {
@@ -48,12 +49,10 @@ const contributorsSchema = new mongoose.Schema({
   },
   country: {
     type: String,
-    required: true,
     trim: true
   },
   state: {
     type: String,
-    required: true,
     trim: true
   },
   city: {
@@ -75,13 +74,22 @@ const contributorsSchema = new mongoose.Schema({
   },
   reason: {
     type: String,
-    required: true,
+    required:true,
     trim: true
   },
   partOfProgramBefore: {
     type: String,
     trim: true
-  }
+  },
+  resumeUpload: {
+    type: String,
+    trim: true
+  },
+  startupServices: {
+    type: String,
+    enum: ['', 'YES', 'NO'],
+    default: ''
+  },
 }, { timestamps: true });
 
 const Contributors = mongoose.models.contributors || mongoose.model("contributors", contributorsSchema);

--- a/utils/models/mentorSchema.js
+++ b/utils/models/mentorSchema.js
@@ -28,7 +28,7 @@ const mentorSchema = new mongoose.Schema({
     required: true,
     trim: true
   },
-  referralCode: {
+  referral: {
     type: String,
     trim: true
   },
@@ -39,6 +39,7 @@ const mentorSchema = new mongoose.Schema({
   },
   linkedInProfileUrl: {
     type: String,
+    required: true,
     trim: true
   },
   discordUsername: {
@@ -48,12 +49,10 @@ const mentorSchema = new mongoose.Schema({
   },
   country: {
     type: String,
-    required: true,
     trim: true
   },
   state: {
     type: String,
-    required: true,
     trim: true
   },
   city: {
@@ -77,7 +76,17 @@ const mentorSchema = new mongoose.Schema({
     type: String,
     required: true,
     trim: true
-  }
+  },
+  resumeUpload: {
+    type: String,
+    trim: true
+  },
+  startupServices: {
+    type: String,
+    enum: ['', 'YES', 'NO'],
+    default: ''
+  },
+  
 }, { timestamps: true });
 
 const Mentor = mongoose.models.mentor || mongoose.model("mentor", mentorSchema);

--- a/utils/models/projectAdminSchema.js
+++ b/utils/models/projectAdminSchema.js
@@ -22,7 +22,7 @@ const projectAdminSchema = new mongoose.Schema({
     required: true,
     trim: true
   },
-  referralCode: {
+  referral: {
     type: String,
     trim: true
   },
@@ -33,6 +33,7 @@ const projectAdminSchema = new mongoose.Schema({
   },
   linkedInProfileUrl: {
     type: String,
+    required: true,
     trim: true
   },
   discordUsername: {
@@ -40,9 +41,30 @@ const projectAdminSchema = new mongoose.Schema({
     required: true,
     trim: true
   },
-  country: {
+  collegeOrOffice: {
     type: String,
     required: true,
+    trim: true
+  },
+  country: {
+    type: String,
+    trim: true
+  },
+  state: {
+    type: String,
+    trim: true
+  },
+  city: {
+    type: String,
+    trim: true
+  },
+  year: {
+    type: String,
+    enum: ['1st Year', '2nd Year', '3rd Year', '4th Year'],
+    required: true
+  },
+  fieldOfStudy: {
+    type: String,
     trim: true
   },
   techStacks: {
@@ -56,18 +78,20 @@ const projectAdminSchema = new mongoose.Schema({
   },
   projectDescription: {
     type: String,
+    required: true,
     trim: true
   },
-  organizationName: {
+  organisationName: {
     type: String,
     trim: true
   },
-  organizationDescription: {
+  organisationDescription: {
     type: String,
     trim: true
   },
   repositoryUrl: {
     type: String,
+    required: true,
     trim: true
   },
   deploymentLink: {
@@ -77,7 +101,16 @@ const projectAdminSchema = new mongoose.Schema({
   expectedMentors: {
     type: Number,
     trim: true
-  }
+  },
+  resumeUpload: {
+    type: String,
+    trim: true
+  },
+  startupServices: {
+    type: String,
+    enum: ['', 'YES', 'NO'],
+    default: ''
+  },
 }, { timestamps: true });
 
 const ProjectAdmin = mongoose.models.projectAdmin || mongoose.model("projectAdmin", projectAdminSchema);


### PR DESCRIPTION
**Description:**

This PR addresses the following things-

- Adding Mails and nodemailer for all roles
- Completing registrations form for other roles than CA
- Adding new fields for resume upload for females, and storing the resume in the database
- Fixing the counter and displaying appropriate message about other role's registrations opening time

**Issues Mentioned-**

https://github.com/GSSoC24/being-an-GSSoc24/issues/200
https://github.com/GSSoC24/being-an-GSSoc24/issues/193

**Images:**

PA's final Page (similarly i have added contributors and mentor page based on the role selected)

![screencapture-localhost-3000-registration-2024-09-13-02_50_41](https://github.com/user-attachments/assets/c1619335-f4ec-4915-af46-e60a4cea8ef3)

Mail that will be sent to the CA - (similar for other roles)

![screencapture-mail-google-mail-u-0-2024-09-13-01_00_33](https://github.com/user-attachments/assets/526e6ed4-7e47-43d0-890d-6e7212762006)

**Video:**

Resume Upload for Females - 

https://github.com/user-attachments/assets/64ecc45f-2853-400e-bb16-3a1b291b8343

since we are not using any cloud storage for storing resume,i converted it in base64URL and stored that in the db.When creating the admin panel,we can simply make a download button with the href link as the base64URL and download the resume (so that we dont have to manually copy each url from the db and paste it in browser to open and view the resume)

**Additional Context:**

@sanjay-kv  @MastanSayyad ,in consultation of @Hemu21 I have used the same template for mail that i made for sponsors just the content is different,do you want any changes?
