### PR TITLE
✔️Moved Nav Menu-Links to 'More' Dropdown Menu

### DIFF
--- a/components/MoreMenu.js
+++ b/components/MoreMenu.js
@@ -113,7 +113,7 @@ const MoreMenu = ({ handleClick }) => {
                       ? `hover:text-primary_orange-0 dark:hover:text-primary_orange-0 dark:text-white`
                       : `hover:text-primary_orange-0 dark:text-white`,
                     "block px-4 py-2 text-sm cursor-pointer"
-                  )}
+                  )} 
                 >
                   CONTACT
                 </a>

--- a/components/MoreMenu.js
+++ b/components/MoreMenu.js
@@ -36,6 +36,90 @@ const MoreMenu = ({ handleClick }) => {
       >
         <Menu.Items className="origin-top-right absolute -right-5 mt-2 w-56 rounded-md shadow-lg dark:bg-black ring-1 bg-white ring-black ring-opacity-5 focus:outline-none">
           <div className="py-1">
+            <Link href={"/caLeaderboard"}>
+              <Menu.Item>
+                {({ active }) => (
+                  <a
+                  onClick={handleClick}
+                  className={classNames(
+                    active
+                      ? `hover:text-primary_orange-0 dark:hover:text-primary_orange-0 dark:text-white`
+                      : `hover:text-primary_orange-0 dark:text-white`,
+                    "block px-4 py-2 text-sm cursor-pointer"
+                  )}
+                >
+                  CA LEADERBOARD
+                </a>
+                )}
+              </Menu.Item>
+            </Link>
+            <Link href={"/jobfair"}>
+              <Menu.Item>
+                {({ active }) => (
+                  <a
+                  onClick={handleClick}
+                   className={classNames(
+                    active
+                      ? `hover:text-primary_orange-0 dark:hover:text-primary_orange-0 dark:text-white`
+                      : `hover:text-primary_orange-0 dark:text-white`,
+                    "block px-4 py-2 text-sm cursor-pointer"
+                  )}>
+                  JOB FAIR
+                </a>
+                )}
+              </Menu.Item>
+            </Link>
+            <Link href={"/faq"}>
+              <Menu.Item>
+                {({ active }) => (
+                  <a
+                  onClick={handleClick}
+                  className={classNames(
+                    active
+                      ? `hover:text-primary_orange-0 dark:hover:text-primary_orange-0 dark:text-white`
+                      : `hover:text-primary_orange-0 dark:text-white`,
+                    "block px-4 py-2 text-sm cursor-pointer"
+                  )}>
+                    FAQ
+                  </a>
+                )}
+              </Menu.Item>
+            </Link>
+            <Link href={"/blog"}>
+              <Menu.Item>
+                {({ active }) => (
+                  <a
+                  onClick={handleClick}
+                  className={classNames(
+                    active
+                      ? `hover:text-primary_orange-0 dark:hover:text-primary_orange-0 dark:text-white`
+                      : `hover:text-primary_orange-0 dark:text-white`,
+                    "block px-4 py-2 text-sm cursor-pointer"
+                  )}
+                >
+                  BLOG
+                </a>
+                )}
+              </Menu.Item>
+            </Link>
+            <Link href={"/contact"}>
+              <Menu.Item>
+                {({ active }) => (
+                  <a
+                  onClick={handleClick}
+                  href="/contact"
+                  className={classNames(
+                    active
+                      ? `hover:text-primary_orange-0 dark:hover:text-primary_orange-0 dark:text-white`
+                      : `hover:text-primary_orange-0 dark:text-white`,
+                    "block px-4 py-2 text-sm cursor-pointer"
+                  )}
+                >
+                  CONTACT
+                </a>
+                )}
+              </Menu.Item>
+            </Link>
             <Link href={"/codeofconduct"}>
               <Menu.Item>
                 {({ active }) => (

--- a/components/MoreMenu.js
+++ b/components/MoreMenu.js
@@ -109,7 +109,7 @@ const MoreMenu = ({ handleClick }) => {
                   onClick={handleClick}
                   href="/contact"
                   className={classNames(
-                    active
+                    active 
                       ? `hover:text-primary_orange-0 dark:hover:text-primary_orange-0 dark:text-white`
                       : `hover:text-primary_orange-0 dark:text-white`,
                     "block px-4 py-2 text-sm cursor-pointer"

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -117,24 +117,6 @@ export const Navbar = () => {
                 LEADERBOARD
               </a>
             </Link>
-            <Link href="/caLeaderboard">
-              <a
-                onClick={handleClick}
-                className="xl:inline-flex xl:w-auto w-full px-2.5 py-2 text-center rounded text-grey-700 text-1xl font-medium mr-1 hover:text-primary_orange-0 dark:hover:text-primary_orange-0 hover:text-xl transition-all link link-underline link-underline-black"
-              >
-                CA LEADERBOARD
-              </a>
-            </Link>
-            <Link href="/jobfair">
-              <a className="xl:inline-flex xl:w-auto w-full px-2.5 py-2 text-center rounded text-grey-700 text-1xl font-medium mr-1 hover:text-primary_orange-0 dark:hover:text-primary_orange-0 hover:text-xl transition-all link link-underline link-underline-black">
-                JOB FAIR
-              </a>
-            </Link>
-            <Link href="/faq">
-              <a className="xl:inline-flex xl:w-auto w-full px-2.5 py-2 text-center rounded text-grey-700 text-1xl font-medium mr-1 hover:text-primary_orange-0 dark:hover:text-primary_orange-0 hover:text-xl transition-all link link-underline link-underline-black">
-                FAQ
-              </a>
-            </Link>
             <Link href="/team">
               <a
                 onClick={handleClick}
@@ -143,21 +125,6 @@ export const Navbar = () => {
                 TEAM
               </a>
             </Link>
-            <Link href="/blog">
-              <a
-                onClick={handleClick}
-                className="xl:inline-flex xl:w-auto w-full px-2.5 py-2 text-center rounded text-grey-700 text-1xl font-medium mr-1 hover:text-primary_orange-0 dark:hover:text-primary_orange-0 hover:text-xl transition-all link link-underline link-underline-black"
-              >
-                BLOG
-              </a>
-            </Link>
-            <a
-              onClick={handleClick}
-              href="/contact"
-              className="xl:inline-flex xl:w-auto w-full px-2.5 py-2 text-center rounded text-grey-700 text-1xl font-medium mr-1 hover:text-primary_orange-0 dark:hover:text-primary_orange-0 hover:text-xl transition-all link link-underline link-underline-black"
-            >
-              CONTACT
-            </a>
             <div className="xl:inline-flex xl:w-auto w-full px-2 text-center rounded">
               <MoreMenu handleClick={handleClick} />
             </div>


### PR DESCRIPTION
closes [issue](https://github.com/GSSoC24/being-an-GSSoc24/issues/212)

This PR reorganizes the navigation bar by moving the following links: 
**`CA Leaderboard` , `Job Fair`, `FAQ`, `Blog`**, and **`Contact`** into the **'More' dropdown** menu to reduce clutter 

### Changes:
- Added the CA Leaderboard, Job Fair, FAQ, Blog, and Contact links to the 'More' dropdown.

![image](https://github.com/user-attachments/assets/1a905044-1fe3-4074-85ca-99a9e7e0727b)


![image](https://github.com/user-attachments/assets/884ce7a7-51ad-46a0-8077-bfa299e3ef69)

![image](https://github.com/user-attachments/assets/f527cad8-0ccd-4cfe-9a45-93d39e969c2c)

@sanjay-kv @Hemu21 @MastanSayyad @RadhikaMalpani1702 @suhanipaliwal  