### PR TITLE
Fix: Fixed issue with timer being shown when user gets back to first slide

### DIFF
--- a/pages/registration.js
+++ b/pages/registration.js
@@ -505,7 +505,7 @@ const Registration = () => {
             )}
             {role !== "CA" && role !== "" && isNext && (
               <div>
-                <h1 className="text-2xl font-normal text-center mt-20 mb-16 w-full max-w-3xl mx-auto">
+                {/* <h1 className="text-2xl font-normal text-center mt-20 mb-16 w-full max-w-3xl mx-auto">
                   <span className="font-bold text-[#f57d33]">
                     Please Wait !
                   </span>{" "}
@@ -544,7 +544,7 @@ const Registration = () => {
                     <span>Mins</span>
                     <span>Seconds</span>
                   </div>
-                </div>
+                </div> */}
               </div>
             )}
             {isRegistrationsOpen && (


### PR DESCRIPTION
**Description:**

This PR fixes the bug in which the timer was being shown when user clicked back to the first slide of the registrations page

**Video:**

https://github.com/user-attachments/assets/96ae4b76-886d-4fa5-b7a9-7b9f10dd48e1

**Additional Context:**

Just commented out the timer for now,if we need it at any point we would be able to get it back 

