### PR TITLE
✔️Removed Duplicate "CA Leaderboard" Link From More-Menu

### DIFF
--- a/components/MoreMenu.js
+++ b/components/MoreMenu.js
@@ -36,23 +36,6 @@ const MoreMenu = ({ handleClick }) => {
       >
         <Menu.Items className="origin-top-right absolute -right-5 mt-2 w-56 rounded-md shadow-lg dark:bg-black ring-1 bg-white ring-black ring-opacity-5 focus:outline-none">
           <div className="py-1">
-            <Link href={"/caLeaderboard"}>
-              <Menu.Item>
-                {({ active }) => (
-                  <a
-                  onClick={handleClick}
-                  className={classNames(
-                    active
-                      ? `hover:text-primary_orange-0 dark:hover:text-primary_orange-0 dark:text-white`
-                      : `hover:text-primary_orange-0 dark:text-white`,
-                    "block px-4 py-2 text-sm cursor-pointer"
-                  )}
-                >
-                  CA LEADERBOARD
-                </a>
-                )}
-              </Menu.Item>
-            </Link>
             <Link href={"/jobfair"}>
               <Menu.Item>
                 {({ active }) => (


### PR DESCRIPTION
**Before-** (There were two links for CA Leaderboard in the navigation..Which Were Creating Duplicacy)

![image](https://github.com/user-attachments/assets/36d6ccfd-5220-4364-86f9-116f86b69ea2)


**After-** (removed the one From More-Menu)

![image](https://github.com/user-attachments/assets/1387dabe-3701-4636-8348-b8440a8c491a)


@Hemu21 @MastanSayyad 