### PR TITLE
Changed CA Leaderboard's Message to Redirect to CA Discussion

### DIFF
--- a/pages/caLeaderboard.js
+++ b/pages/caLeaderboard.js
@@ -323,7 +323,7 @@ const CALeaderboard = () => {
               )}
               <a
                 className="ml-2 underline hover:no-underline"
-                href="https://github.com/orgs/GSSoC24/discussions/725"
+                href="https://github.com/orgs/GSSoC24/discussions/740"
                 target="_blank"
                 rel="noreferrer"
               >

--- a/pages/caLeaderboard.js
+++ b/pages/caLeaderboard.js
@@ -323,11 +323,11 @@ const CALeaderboard = () => {
               )}
               <a
                 className="ml-2 underline hover:no-underline"
-                href="https://github.com/GSSoC24/Contributor/discussions/288"
+                href="https://github.com/orgs/GSSoC24/discussions/725"
                 target="_blank"
                 rel="noreferrer"
               >
-                More details about badges
+                More details about CAs and CA leaderboard
               </a>
             </p>
           </div>


### PR DESCRIPTION
**Description:**

This PR changes the CA Leaderboard's message and changes redirect link to https://github.com/orgs/GSSoC24/discussions/740

**Image:**

![Screenshot (706)](https://github.com/user-attachments/assets/37aa0abe-8337-450b-8bb7-f1a25a4cbbb8)

**Additional Context:**

N/A